### PR TITLE
Allow running an arbitrary program with eos-kolibri-manage

### DIFF
--- a/src/eos-kolibri-manage.in
+++ b/src/eos-kolibri-manage.in
@@ -17,14 +17,22 @@ if [ ! -f "${KOLIBRI_HOME}/db.sqlite3" ]; then
   exit 1
 fi
 
-if [[ "$1" == *"/"* ]]; then
+case "$1" in
+*"/"*)
   FLATPAK_COMMAND="$1"
   SUBCOMMAND=""
   shift
-else
+  ;;
+"listcontent")
+  FLATPAK_COMMAND="/app/bin/kolibri-listcontent.py"
+  SUBCOMMAND=""
+  shift
+  ;;
+*)
   FLATPAK_COMMAND="/app/bin/kolibri"
   SUBCOMMAND="manage"
-fi
+  ;;
+esac
 
 runuser -u @KOLIBRI_USER@ -- flatpak run \
   --no-desktop \
@@ -32,6 +40,6 @@ runuser -u @KOLIBRI_USER@ -- flatpak run \
   --filesystem="${KOLIBRI_HOME}" \
   --command="${FLATPAK_COMMAND}" \
   @KOLIBRI_FLATPAK_ID@ \
-  "${SUBCOMMAND}" \
+  ${SUBCOMMAND} \
   $@
 

--- a/src/eos-kolibri-manage.in
+++ b/src/eos-kolibri-manage.in
@@ -17,12 +17,21 @@ if [ ! -f "${KOLIBRI_HOME}/db.sqlite3" ]; then
   exit 1
 fi
 
+if [[ "$1" == *"/"* ]]; then
+  FLATPAK_COMMAND="$1"
+  SUBCOMMAND=""
+  shift
+else
+  FLATPAK_COMMAND="/app/bin/kolibri"
+  SUBCOMMAND="manage"
+fi
+
 runuser -u @KOLIBRI_USER@ -- flatpak run \
   --no-desktop \
   --env=KOLIBRI_HOME="${KOLIBRI_HOME}" \
   --filesystem="${KOLIBRI_HOME}" \
-  --command=/app/bin/kolibri \
+  --command="${FLATPAK_COMMAND}" \
   @KOLIBRI_FLATPAK_ID@ \
-  manage \
+  "${SUBCOMMAND}" \
   $@
 


### PR DESCRIPTION
https://phabricator.endlessm.com/T31824

With this change, it is possible to do `eos-kolibri-manage /app/bin/kolibri-listcontent.py` (after we merge flathub/org.learningequality.Kolibri#32).