### PR TITLE
Add more interfaces to dbus policy

### DIFF
--- a/data/dbus/org.learningequality.Kolibri.Daemon.conf.in
+++ b/data/dbus/org.learningequality.Kolibri.Daemon.conf.in
@@ -11,5 +11,6 @@
     <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.freedesktop.DBus.Introspectable" />
     <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.freedesktop.DBus.Properties" />
     <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.learningequality.Kolibri.Daemon" />
+    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.learningequality.Kolibri.Daemon.Main" />
   </policy>
 </busconfig>


### PR DESCRIPTION
Future versions of Kolibri may use a dbus interface named
org.learningequality.Kolibri.Daemon.Main.

https://phabricator.endlessm.com/T32687