### PR TITLE
Always set XDG_DATA_DIRS

### DIFF
--- a/data/user-environment-generators/61-eos-kolibri.sh.in
+++ b/data/user-environment-generators/61-eos-kolibri.sh.in
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-if flatpak info --system --show-ref @KOLIBRI_FLATPAK_ID@ 1>/dev/null 2>/dev/null; then
-  XDG_DATA_DIRS="@KOLIBRI_DATA_DIR@/content/xdg/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-  echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"
-fi
+XDG_DATA_DIRS="@KOLIBRI_DATA_DIR@/content/xdg/share:${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+echo "XDG_DATA_DIRS=$XDG_DATA_DIRS"


### PR DESCRIPTION
With the newest version of the Kolibri flatpak, this check
is no longer required.

https://phabricator.endlessm.com/T32893