### PR TITLE
Execute Kolibri daemon

### DIFF
--- a/src/eos-kolibri-daemon.in
+++ b/src/eos-kolibri-daemon.in
@@ -2,7 +2,7 @@
 
 : "${KOLIBRI_HOME:=@KOLIBRI_DATA_DIR@}"
 
-flatpak run \
+exec flatpak run \
   --no-desktop \
   --env=KOLIBRI_HOME="${KOLIBRI_HOME}" \
   --filesystem="${KOLIBRI_HOME}" \


### PR DESCRIPTION
The eos-kolibri-daemon wrapper script does nothing after it runs the
Kolibri flatpak, so it might as well replace the shell script with
`exec` so there's not a useless shell process running on the system that
also shows up as the main process in the systemd service.