### PR TITLE
Parameterize the DBus interface and the executed flatpak ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,10 @@ Provides tools to manage the system-wide Kolibri installation:
   instance to the system Kolibri instance.
 - `eos-kolibri-listcontent`: List content installed in Kolibri. This is useful
   to generate configuration for eos-image-builder.
+
+## Build Configuration
+
+The meson option `kolibri_flatpak_id` is set as `org.learningequality.Kolibri`
+for the `org.learningequality.Kolibri` flatpak and the dbus system service
+`org.learningequality.Kolibri.Daemon` by default. It can be set as another
+flatpak ID and will change the dbus system service accordingly.

--- a/data/dbus/meson.build
+++ b/data/dbus/meson.build
@@ -11,3 +11,17 @@ configure_file(
     configuration: eos_kolibri_config,
     install_dir: dbus_system_conf_dir
 )
+
+configure_file(
+    input: 'org.learningequality.Kolibri.Daemon.service.in',
+    output: '@0@.service'.format(endlesskey_daemon_service),
+    configuration: endless_key_config,
+    install_dir: dbus_system_bus_services_dir
+)
+
+configure_file(
+    input: 'org.learningequality.Kolibri.Daemon.conf.in',
+    output: '@0@.conf'.format(endlesskey_daemon_service),
+    configuration: endless_key_config,
+    install_dir: dbus_system_conf_dir
+)

--- a/data/dbus/org.learningequality.Kolibri.Daemon.conf.in
+++ b/data/dbus/org.learningequality.Kolibri.Daemon.conf.in
@@ -10,7 +10,7 @@
   <policy context="default">
     <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.freedesktop.DBus.Introspectable" />
     <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.freedesktop.DBus.Properties" />
-    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.learningequality.Kolibri.Daemon" />
-    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.learningequality.Kolibri.Daemon.Main" />
+    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="@KOLIBRI_DAEMON_SERVICE@" />
+    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="@KOLIBRI_DAEMON_SERVICE@.Main" />
   </policy>
 </busconfig>

--- a/data/systemd/meson.build
+++ b/data/systemd/meson.build
@@ -4,3 +4,10 @@ configure_file(
     configuration: eos_kolibri_config,
     install_dir: systemd_system_unit_dir
 )
+
+configure_file(
+    input: 'dbus-org.learningequality.Kolibri.Daemon.service.in',
+    output: 'dbus-@0@.service'.format(endlesskey_daemon_service),
+    configuration: endless_key_config,
+    install_dir: systemd_system_unit_dir
+)

--- a/data/tmpfiles.d/meson.build
+++ b/data/tmpfiles.d/meson.build
@@ -4,3 +4,10 @@ configure_file(
     configuration: eos_kolibri_config,
     install_dir: systemd_tmpfiles_dir
 )
+
+configure_file(
+    input: 'eos-kolibri.conf.in',
+    output: 'endless-key.conf',
+    configuration: endless_key_config,
+    install_dir: systemd_tmpfiles_dir
+)

--- a/data/user-environment-generators/meson.build
+++ b/data/user-environment-generators/meson.build
@@ -5,3 +5,11 @@ configure_file(
     install_dir: systemd_user_environment_generators_dir,
     install_mode: 'rwxr-xr-x'
 )
+
+configure_file(
+    input: '61-eos-kolibri.sh.in',
+    output: '61-endless-key.sh',
+    configuration: endless_key_config,
+    install_dir: systemd_user_environment_generators_dir,
+    install_mode: 'rwxr-xr-x'
+)

--- a/meson.build
+++ b/meson.build
@@ -81,5 +81,25 @@ eos_kolibri_config.set('KOLIBRI_DATA_DIR', kolibri_data_dir)
 eos_kolibri_config.set('KOLIBRI_FLATPAK_ID', kolibri_flatpak_id)
 eos_kolibri_config.set('KOLIBRI_DAEMON_SERVICE', kolibri_daemon_service)
 
+
+endlesskey_user_home = get_option('endlesskey_user_home')
+if endlesskey_user_home == ''
+    endlesskey_user_home = join_paths(get_option('prefix'), get_option('localstatedir'), 'lib', 'endless-key')
+endif
+endlesskey_data_dir = join_paths(endlesskey_user_home, 'data')
+endlesskey_flatpak_id = get_option('endlesskey_flatpak_id')
+endlesskey_daemon_service = '@0@.Daemon'.format(endlesskey_flatpak_id)
+
+endless_key_config = configuration_data()
+endless_key_config.set('bindir', bindir)
+endless_key_config.set('libexecdir', libexecdir)
+endless_key_config.set('PYTHON', 'python3')
+endless_key_config.set('PYTHON_INSTALL_DIR', python_install_dir)
+endless_key_config.set('KOLIBRI_USER', kolibri_user)
+endless_key_config.set('KOLIBRI_USER_HOME', endlesskey_user_home)
+endless_key_config.set('KOLIBRI_DATA_DIR', endlesskey_data_dir)
+endless_key_config.set('KOLIBRI_FLATPAK_ID', endlesskey_flatpak_id)
+endless_key_config.set('KOLIBRI_DAEMON_SERVICE', endlesskey_daemon_service)
+
 subdir('data')
 subdir('src')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -48,8 +48,22 @@ option(
 )
 
 option(
+    'endlesskey_user_home',
+    type: 'string',
+    value: '',
+    description: 'home directory for the Endless Key system user [default=$localstatedir/lib/endless-key]'
+)
+
+option(
     'kolibri_flatpak_id',
     type: 'string',
     value: 'org.learningequality.Kolibri',
     description: 'identifier for the Kolibri flatpak [default=org.learningequality.Kolibri]'
+)
+
+option(
+    'endlesskey_flatpak_id',
+    type: 'string',
+    value: 'org.endlessos.Key',
+    description: 'identifier for the Endless Key flatpak [default=org.endlessos.Key]'
 )

--- a/src/endless-key-listcontent.in
+++ b/src/endless-key-listcontent.in
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+@bindir@/endless-key-manage listcontent $@

--- a/src/eos-kolibri-export
+++ b/src/eos-kolibri-export
@@ -29,6 +29,8 @@ import shutil
 import subprocess
 import time
 
+from eos_kolibri.config import KOLIBRI_FLATPAK_ID
+
 logger = logging.getLogger(os.path.basename(__file__))
 
 
@@ -38,9 +40,9 @@ def system_server_proxy():
         bus,
         Gio.DBusProxyFlags.NONE,
         None,  # interface info
-        'org.learningequality.Kolibri.Daemon',
-        '/org/learningequality/Kolibri/Daemon/Main',
-        'org.learningequality.Kolibri.Daemon',
+        KOLIBRI_FLATPAK_ID + '.Daemon',
+        KOLIBRI_FLATPAK_ID.replace('.', '/') + '/Daemon/Main',
+        KOLIBRI_FLATPAK_ID + '.Daemon',
     )
 
 
@@ -86,7 +88,7 @@ def run_kolibri(kolibri_home, *args, program='/app/bin/kolibri', **kwargs):
         '--env=KOLIBRI_NO_FILE_BASED_LOGGING=true',
         f'--filesystem={kolibri_home}',
         f'--command={program}',
-        'org.learningequality.Kolibri',
+        KOLIBRI_FLATPAK_ID,
     ) + args
     return run(cmd, **kwargs)
 

--- a/src/eos-kolibri-export
+++ b/src/eos-kolibri-export
@@ -31,18 +31,24 @@ import time
 
 from eos_kolibri.config import KOLIBRI_FLATPAK_ID
 
+FLATPAK_ID = KOLIBRI_FLATPAK_ID
+
 logger = logging.getLogger(os.path.basename(__file__))
 
 
 def system_server_proxy():
     bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
+    bus_name = FLATPAK_ID + '.Daemon'
+    object_path = bus_name.replace('.', '/') + '/Main'
+    interface_name = bus_name
+
     return Gio.DBusProxy.new_sync(
         bus,
         Gio.DBusProxyFlags.NONE,
         None,  # interface info
-        KOLIBRI_FLATPAK_ID + '.Daemon',
-        KOLIBRI_FLATPAK_ID.replace('.', '/') + '/Daemon/Main',
-        KOLIBRI_FLATPAK_ID + '.Daemon',
+        bus_name,
+        object_path,
+        interface_name,
     )
 
 
@@ -88,7 +94,7 @@ def run_kolibri(kolibri_home, *args, program='/app/bin/kolibri', **kwargs):
         '--env=KOLIBRI_NO_FILE_BASED_LOGGING=true',
         f'--filesystem={kolibri_home}',
         f'--command={program}',
-        KOLIBRI_FLATPAK_ID,
+        FLATPAK_ID,
     ) + args
     return run(cmd, **kwargs)
 
@@ -108,10 +114,16 @@ def main():
         const=logging.DEBUG,
         help='enable debugging messages',
     )
+    ap.add_argument(
+        '--flatpak',
+        default=KOLIBRI_FLATPAK_ID,
+        help=f'execute the flatpak (default {KOLIBRI_FLATPAK_ID})'
+    )
 
     args = ap.parse_args()
     logging.basicConfig(level=args.log_level)
 
+    FLATPAK_ID = args.flatpak
     kolibri_home = os.path.realpath(args.dir)
     kolibri_db = os.path.join(kolibri_home, 'db.sqlite3')
     kolibri_content = os.path.join(kolibri_home, 'content')

--- a/src/eos-kolibri-import
+++ b/src/eos-kolibri-import
@@ -32,6 +32,8 @@ from tempfile import TemporaryDirectory
 
 from eos_kolibri.config import KOLIBRI_FLATPAK_ID
 
+FLATPAK_ID = KOLIBRI_FLATPAK_ID
+
 logger = logging.getLogger(os.path.basename(__file__))
 
 
@@ -45,13 +47,17 @@ def system_server_proxy(autostart=False):
     flags = Gio.DBusProxyFlags.NONE
     if not autostart:
         flags |= Gio.DBusProxyFlags.DO_NOT_AUTO_START
+    bus_name = FLATPAK_ID + '.Daemon'
+    object_path = bus_name.replace('.', '/') + '/Main'
+    interface_name = bus_name
+
     return Gio.DBusProxy.new_sync(
         bus,
         flags,
         None,  # interface info
-        KOLIBRI_FLATPAK_ID + '.Daemon',
-        KOLIBRI_FLATPAK_ID.replace('.', '/') + '/Daemon/Main',
-        KOLIBRI_FLATPAK_ID + '.Daemon',
+        bus_name,
+        object_path,
+        interface_name,
     )
 
 
@@ -133,7 +139,7 @@ class KolibriServer:
             f'--filesystem={kolibri_home}',
             f'--filesystem={orig_content}',
             '--command=/app/bin/kolibri',
-            KOLIBRI_FLATPAK_ID,
+            FLATPAK_ID,
             'start',
             '--foreground',
         )
@@ -275,8 +281,14 @@ def main():
         const=logging.DEBUG,
         help='enable debugging messages',
     )
+    ap.add_argument(
+        '--flatpak',
+        default=KOLIBRI_FLATPAK_ID,
+        help=f'execute the flatpak (default {KOLIBRI_FLATPAK_ID})'
+    )
 
     args = ap.parse_args()
+    FLATPAK_ID = args.flatpak
     logging.basicConfig(level=args.log_level)
     with KolibriServer(args.dir) as server:
         import_channels(args.dir, server.url)

--- a/src/eos-kolibri-import
+++ b/src/eos-kolibri-import
@@ -30,6 +30,8 @@ import subprocess
 import time
 from tempfile import TemporaryDirectory
 
+from eos_kolibri.config import KOLIBRI_FLATPAK_ID
+
 logger = logging.getLogger(os.path.basename(__file__))
 
 
@@ -47,9 +49,9 @@ def system_server_proxy(autostart=False):
         bus,
         flags,
         None,  # interface info
-        'org.learningequality.Kolibri.Daemon',
-        '/org/learningequality/Kolibri/Daemon/Main',
-        'org.learningequality.Kolibri.Daemon',
+        KOLIBRI_FLATPAK_ID + '.Daemon',
+        KOLIBRI_FLATPAK_ID.replace('.', '/') + '/Daemon/Main',
+        KOLIBRI_FLATPAK_ID + '.Daemon',
     )
 
 
@@ -131,7 +133,7 @@ class KolibriServer:
             f'--filesystem={kolibri_home}',
             f'--filesystem={orig_content}',
             '--command=/app/bin/kolibri',
-            'org.learningequality.Kolibri',
+            KOLIBRI_FLATPAK_ID,
             'start',
             '--foreground',
         )

--- a/src/eos-kolibri-migrate.in
+++ b/src/eos-kolibri-migrate.in
@@ -2,5 +2,5 @@
 
 export PYTHONPATH=@PYTHON_INSTALL_DIR@
 
-@PYTHON@ -m "eos_kolibri.eos_kolibri_migrate.main" "$@"
+@PYTHON@ -m "eos_kolibri.eos_kolibri_migrate.main" --flatpak @KOLIBRI_FLATPAK_ID@ "$@"
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -36,6 +36,42 @@ configure_file(
     install_mode: 'rwxr-xr-x'
 )
 
+configure_file(
+    input: 'eos-kolibri-migrate.in',
+    output: 'endless-key-migrate',
+    configuration: endless_key_config,
+    install: true,
+    install_dir: bindir,
+    install_mode: 'rwxr-xr-x'
+)
+
+configure_file(
+    input: 'eos-kolibri-manage.in',
+    output: 'endless-key-manage',
+    configuration: endless_key_config,
+    install: true,
+    install_dir: bindir,
+    install_mode: 'rwxr-xr-x'
+)
+
+configure_file(
+    input: 'endless-key-listcontent.in',
+    output: 'endless-key-listcontent',
+    configuration: endless_key_config,
+    install: true,
+    install_dir: bindir,
+    install_mode: 'rwxr-xr-x'
+)
+
+configure_file(
+    input: 'eos-kolibri-daemon.in',
+    output: 'endless-key-daemon',
+    configuration: endless_key_config,
+    install: true,
+    install_dir: libexecdir,
+    install_mode: 'rwxr-xr-x'
+)
+
 install_data(
     'eos-kolibri-export',
     install_dir: bindir,


### PR DESCRIPTION
Parameterize the DBus interface and the executed flatpak ID with the Meson option "kolibri_flatpak_id". It is the set value of config's "KOLIBRI_FLATPAK_ID". Therefore, the DBus interface and the executed flatpak ID can be configured during build time.

Fixes: https://github.com/endlessm/eos-kolibri/issues/20