### PR TITLE
build: Set kolibri_flatpak_id's default value as org.endlessos.Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ backend to run as a system service) as well as eos-kolibri-tools.
 
 Provides dbus and systemd configuration to integrate the Kolibri flatpak with
 Endless OS. It creates a `kolibri` system user, and dbus system service
-configuration for `org.learningequality.Kolibri.Daemon`. This dbus service uses
-the `org.learningequality.Kolibri` flatpak.
+configuration for `org.endlessos.Key.Daemon`. This dbus service uses
+the `org.endlessos.Key` flatpak.
 
 The `KOLIBRI_USE_SYSTEM_INSTANCE` environment variable is set globally so the
 Kolibri front-end knows to communicate with the system service rather than a

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -50,6 +50,6 @@ option(
 option(
     'kolibri_flatpak_id',
     type: 'string',
-    value: 'org.learningequality.Kolibri',
-    description: 'identifier for the Kolibri flatpak [default=org.learningequality.Kolibri]'
+    value: 'org.endlessos.Key',
+    description: 'identifier for the Kolibri flatpak [default=org.endlessos.Key]'
 )


### PR DESCRIPTION
Make eos-kolibri using Endless Key flavour.

Fixes: https://github.com/endlessm/eos-kolibri/issues/20