### PR TITLE
Fix DBus object path by adding missed leading '/'

### DIFF
--- a/src/eos-kolibri-export
+++ b/src/eos-kolibri-export
@@ -39,7 +39,7 @@ logger = logging.getLogger(os.path.basename(__file__))
 def system_server_proxy():
     bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
     bus_name = FLATPAK_ID + '.Daemon'
-    object_path = bus_name.replace('.', '/') + '/Main'
+    object_path = '/' + bus_name.replace('.', '/') + '/Main'
     interface_name = bus_name
 
     return Gio.DBusProxy.new_sync(

--- a/src/eos-kolibri-import
+++ b/src/eos-kolibri-import
@@ -48,7 +48,7 @@ def system_server_proxy(autostart=False):
     if not autostart:
         flags |= Gio.DBusProxyFlags.DO_NOT_AUTO_START
     bus_name = FLATPAK_ID + '.Daemon'
-    object_path = bus_name.replace('.', '/') + '/Main'
+    object_path = '/' + bus_name.replace('.', '/') + '/Main'
     interface_name = bus_name
 
     return Gio.DBusProxy.new_sync(


### PR DESCRIPTION
The leading '/' of the DBus object path is missed originally.

Fixes: ab29432e70e1 ("Add "--flatpak" argument into export, import and migrate")