### PR TITLE
Use original interface name org.learningequality.Kolibri.Daemon

### DIFF
--- a/data/dbus/org.learningequality.Kolibri.Daemon.conf.in
+++ b/data/dbus/org.learningequality.Kolibri.Daemon.conf.in
@@ -10,7 +10,7 @@
   <policy context="default">
     <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.freedesktop.DBus.Introspectable" />
     <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.freedesktop.DBus.Properties" />
-    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="@KOLIBRI_DAEMON_SERVICE@" />
-    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="@KOLIBRI_DAEMON_SERVICE@.Main" />
+    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.learningequality.Kolibri.Daemon" />
+    <allow send_destination="@KOLIBRI_DAEMON_SERVICE@" send_interface="org.learningequality.Kolibri.Daemon.Main" />
   </policy>
 </busconfig>

--- a/src/eos-kolibri-export
+++ b/src/eos-kolibri-export
@@ -40,7 +40,7 @@ def system_server_proxy():
     bus = Gio.bus_get_sync(Gio.BusType.SYSTEM, None)
     bus_name = FLATPAK_ID + '.Daemon'
     object_path = '/' + bus_name.replace('.', '/') + '/Main'
-    interface_name = bus_name
+    interface_name = 'org.learningequality.Kolibri.Daemon'
 
     return Gio.DBusProxy.new_sync(
         bus,

--- a/src/eos-kolibri-import
+++ b/src/eos-kolibri-import
@@ -49,7 +49,7 @@ def system_server_proxy(autostart=False):
         flags |= Gio.DBusProxyFlags.DO_NOT_AUTO_START
     bus_name = FLATPAK_ID + '.Daemon'
     object_path = '/' + bus_name.replace('.', '/') + '/Main'
-    interface_name = bus_name
+    interface_name = 'org.learningequality.Kolibri.Daemon'
 
     return Gio.DBusProxy.new_sync(
         bus,


### PR DESCRIPTION
According to the discussion [1], use the original interface name "org.learningequality.Kolibri.Daemon" for both Kolibri and Endless Key flatpaks [2]. So, eos-kolibri sends to the original DBus interface name as well.

[1]: https://github.com/endlessm/kolibri-desktop-auth-plugin/pull/12
[2]: https://github.com/endlessm/endless-key-flatpak/pull/14