### PR TITLE
Remove user environment generator for Endless Key

### DIFF
--- a/data/user-environment-generators/meson.build
+++ b/data/user-environment-generators/meson.build
@@ -5,11 +5,3 @@ configure_file(
     install_dir: systemd_user_environment_generators_dir,
     install_mode: 'rwxr-xr-x'
 )
-
-configure_file(
-    input: '61-eos-kolibri.sh.in',
-    output: '61-endless-key.sh',
-    configuration: endless_key_config,
-    install_dir: systemd_user_environment_generators_dir,
-    install_mode: 'rwxr-xr-x'
-)


### PR DESCRIPTION
Closes: https://github.com/endlessm/eos-kolibri/issues/29