### PR TITLE
Pass KOLIBRI_DEBUG through daemon script

### DIFF
--- a/src/eos-kolibri-daemon.in
+++ b/src/eos-kolibri-daemon.in
@@ -1,10 +1,12 @@
 #!/bin/sh
 
 : "${KOLIBRI_HOME:=@KOLIBRI_DATA_DIR@}"
+: "${KOLIBRI_DEBUG:=false}"
 
 exec flatpak run \
   --no-desktop \
   --env=KOLIBRI_HOME="${KOLIBRI_HOME}" \
+  --env=KOLIBRI_DEBUG="${KOLIBRI_DEBUG}" \
   --filesystem="${KOLIBRI_HOME}" \
   --system-own-name=@KOLIBRI_DAEMON_SERVICE@ \
   --system-talk-name=org.freedesktop.Accounts \


### PR DESCRIPTION
Soon the flatpak will use the `KOLIBRI_DEBUG` environment variable to enable debug mode. Pass the environment variable through while defaulting the value to `false`.

Helps: https://github.com/endlessm/endless-key-flatpak/issues/123