### PR TITLE
Prefer flatpak override

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ per-session one. However, for Endless Key flatpak, it should check
 `ENDLESS_KEY_USE_SYSTEM_INSTANCE` environment and make front-end communicate
 with the system service if it is set, instead of `KOLIBRI_USE_SYSTEM_INSTANCE`.
 
+The dbus system service is executed from the
+`dbus-org.learningequality.Kolibri.Daemon.service` (or
+`dbus-org.endlessos.Key.Daemon.service`) systemd unit. Normally the way to set
+environment variables for systemd services is to add a drop-in configuration.
+However, since the daemon is ultimately executed with `flatpak run`, flatpak
+manages the execution environment. In that case, environment variables for the
+daemon should be set with a flatpak override. For example:
+
+```
+flatpak override --env=KOLIBRI_DEBUG=1 org.learningequality.Kolibri
+```
+
 ## eos-kolibri-tools
 
 Provides tools to manage the system-wide Kolibri installation:

--- a/src/eos-kolibri-daemon.in
+++ b/src/eos-kolibri-daemon.in
@@ -1,12 +1,10 @@
 #!/bin/sh
 
 : "${KOLIBRI_HOME:=@KOLIBRI_DATA_DIR@}"
-: "${KOLIBRI_DEBUG:=false}"
 
 exec flatpak run \
   --no-desktop \
   --env=KOLIBRI_HOME="${KOLIBRI_HOME}" \
-  --env=KOLIBRI_DEBUG="${KOLIBRI_DEBUG}" \
   --filesystem="${KOLIBRI_HOME}" \
   --system-own-name=@KOLIBRI_DAEMON_SERVICE@ \
   --system-talk-name=org.freedesktop.Accounts \


### PR DESCRIPTION
After testing and determining that `flatpak override` is the best way to get environment variables into the daemon, I decided that the potentially conflicting marshaling of `KOLIBRI_DEBUG` in 1c4a22c8c3f8ef3166858ed431ae025971abb7cc should be removed. I was able to test that `sudo flatpak override --env=KOLIBRI_DEBUG=1 org.endlessos.Key.Devel` worked after cobbling together an `endless-key-devel-daemon` setup.