### PR TITLE
Set KillMode=mixed for dbus system service

### DIFF
--- a/data/systemd/dbus-org.learningequality.Kolibri.Daemon.service.in
+++ b/data/systemd/dbus-org.learningequality.Kolibri.Daemon.service.in
@@ -6,5 +6,6 @@ ConditionPathExists=/var/lib/flatpak/app/@KOLIBRI_FLATPAK_ID@
 Type=dbus
 BusName=@KOLIBRI_DAEMON_SERVICE@
 ExecStart=@libexecdir@/@KOLIBRI_CMD_PREFIX@-daemon
+KillMode=mixed
 User=@KOLIBRI_USER@
 PrivateTmp=yes


### PR DESCRIPTION
The default KillMode=control-group blocks while several worker processes remain open.

-----

It looks like what's happening here is Kolibri creates a process pool for a bunch of things, and the processes in that process pool don't handle SIGTERM properly. But if we SIGTERM just the main process, things work out fine.

I have a suspicion our main process is probably not being managed well either thanks to some awkwardness with `flatpak run`, and that should probably be addressed at some point. But this at least stops the dbus service from blocking shutdown for 90 seconds.